### PR TITLE
feat: cart 도메인 crud 기능 추가

### DIFF
--- a/src/main/kotlin/com/example/commerce/cart/controller/CartController.kt
+++ b/src/main/kotlin/com/example/commerce/cart/controller/CartController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*
 class CartController(
     private val cartService: CartService
 ){
-    @GetMapping("{user-id}")
+    @GetMapping("/{user-id}")
     fun getCart(@PathVariable("user-id") userId : Long): ResponseEntity<CartResponse> {
         val response = cartService.getCart(userId)
         val status = HttpStatus.OK

--- a/src/main/kotlin/com/example/commerce/cart/controller/CartController.kt
+++ b/src/main/kotlin/com/example/commerce/cart/controller/CartController.kt
@@ -1,0 +1,51 @@
+package com.example.commerce.cart.controller
+
+import com.example.commerce.cart.dto.request.AddCartItemRequest
+import com.example.commerce.cart.dto.request.ModifyCartItemRequest
+import com.example.commerce.cart.dto.response.CartResponse
+import com.example.commerce.cart.service.CartService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/cart")
+class CartController(
+    private val cartService: CartService
+){
+    @GetMapping("{user-id}")
+    fun getCart(@PathVariable("user-id") userId : Long): ResponseEntity<CartResponse> {
+        val response = cartService.getCart(userId)
+        val status = HttpStatus.OK
+        return ResponseEntity.status(status).body(response)
+    }
+
+    @PostMapping("/items/{user-id}")
+    fun addCartItem(
+        @PathVariable("user-id") userId: Long,
+        @RequestBody request: AddCartItemRequest
+    ): ResponseEntity<Void> {
+        cartService.addCartItem(userId, request)
+        val status = HttpStatus.OK
+        return ResponseEntity.status(status).build()
+    }
+
+    @PutMapping("/items/{cart-item-id}")
+    fun modifyCartItem(
+        @PathVariable("cart-item-id") cartItemId: Long,
+        @RequestBody request: ModifyCartItemRequest,
+    ): ResponseEntity<Void> {
+        cartService.modifyCartItem(cartItemId, request)
+        val status = HttpStatus.OK
+        return ResponseEntity.status(status).build()
+    }
+
+    @DeleteMapping("/items/{cart-item-id}")
+    fun deleteCartItem(
+        @PathVariable("cart-item-id") cartItemId: Long
+    ): ResponseEntity<Void>{
+        cartService.deleteCartItem(cartItemId)
+        val status = HttpStatus.OK
+        return ResponseEntity.status(status).build()
+    }
+}

--- a/src/main/kotlin/com/example/commerce/cart/domain/CartItem.kt
+++ b/src/main/kotlin/com/example/commerce/cart/domain/CartItem.kt
@@ -1,0 +1,34 @@
+package com.example.commerce.cart.domain
+
+import com.example.commerce.common.BaseEntity
+import com.example.commerce.product.domain.Product
+import com.example.commerce.user.domain.User
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "cart_item")
+class CartItem(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    val product: Product,
+
+    quantity: Int,  // private 으로 필드 접근을 막지 못하는 이유는 jpa 가 필드를 읽을 수 없기 때문
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+) : BaseEntity(){
+
+    @Column(name = "quantity", nullable = false)
+    var quantity: Int = quantity
+        protected set
+
+    fun applyQuantity(value: Int){
+        this.quantity = if (value < 1) 1 else value
+    }
+}

--- a/src/main/kotlin/com/example/commerce/cart/dto/request/AddCartItemRequest.kt
+++ b/src/main/kotlin/com/example/commerce/cart/dto/request/AddCartItemRequest.kt
@@ -1,0 +1,7 @@
+package com.example.commerce.cart.dto.request
+
+data class AddCartItemRequest(
+    val productId: Long,
+    val quantity: Int,
+) {
+}

--- a/src/main/kotlin/com/example/commerce/cart/dto/request/ModifyCartItemRequest.kt
+++ b/src/main/kotlin/com/example/commerce/cart/dto/request/ModifyCartItemRequest.kt
@@ -1,0 +1,5 @@
+package com.example.commerce.cart.dto.request
+
+data class ModifyCartItemRequest(
+    val quantity: Int
+)

--- a/src/main/kotlin/com/example/commerce/cart/dto/response/CartResponse.kt
+++ b/src/main/kotlin/com/example/commerce/cart/dto/response/CartResponse.kt
@@ -1,0 +1,19 @@
+package com.example.commerce.cart.dto.response
+
+import java.math.BigDecimal
+
+data class CartResponse(
+    val userId: Long,
+    val items: List<CartItemResponse>,
+)
+
+data class CartItemResponse(
+    val id: Long,
+    val productId: Long,
+    val productName: String,
+    val thumbnailUrl: String,
+    val description: String,
+    val shortDescription: String,
+    val price: BigDecimal,
+    val quantity: Int,
+)

--- a/src/main/kotlin/com/example/commerce/cart/repository/CartItemRepository.kt
+++ b/src/main/kotlin/com/example/commerce/cart/repository/CartItemRepository.kt
@@ -1,0 +1,9 @@
+package com.example.commerce.cart.repository
+
+import com.example.commerce.cart.domain.CartItem
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CartItemRepository : JpaRepository<CartItem, Long> {
+    fun findByUserIdAndProductId(userId: Long, productId: Long): CartItem?
+    fun findByUserId(userId: Long): List<CartItem>
+}

--- a/src/main/kotlin/com/example/commerce/cart/service/CartService.kt
+++ b/src/main/kotlin/com/example/commerce/cart/service/CartService.kt
@@ -1,0 +1,90 @@
+package com.example.commerce.cart.service
+
+import com.example.commerce.cart.domain.CartItem
+import com.example.commerce.cart.dto.request.AddCartItemRequest
+import com.example.commerce.cart.dto.request.ModifyCartItemRequest
+import com.example.commerce.cart.dto.response.CartItemResponse
+import com.example.commerce.cart.dto.response.CartResponse
+import com.example.commerce.cart.repository.CartItemRepository
+import com.example.commerce.common.exception.CustomException
+import com.example.commerce.common.exception.ErrorCode.CART_ITEM_NOT_FOUND
+import com.example.commerce.common.exception.ErrorCode.USER_NOT_FOUND
+import com.example.commerce.common.exception.ErrorCode.PRODUCT_NOT_FOUND
+import com.example.commerce.product.domain.Product
+import com.example.commerce.product.repository.ProductRepository
+import com.example.commerce.user.domain.User
+import com.example.commerce.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CartService(
+    private val cartItemRepository: CartItemRepository,
+    private val productRepository: ProductRepository,
+    private val userRepository: UserRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getCart(userId: Long): CartResponse {
+        val user: User =  userRepository.findById(userId)
+            .orElseThrow{ CustomException(USER_NOT_FOUND) }
+        val items = cartItemRepository.findByUserId(user.id!!)
+        val productMap = productRepository.findAllById(items.map { it.product.id })
+            .associateBy{ it.id } // productId 를 key 로 하고, product 객체를  value 로 하는 map 으로 리턴
+
+        return CartResponse(
+            userId = user.id!!,
+            items = items.filter{ productMap.containsKey(it.product.id) } // 상품이 존재하는 장바구니 아이템만 선택(productMap 에 없는 상품 제외)
+                .map{ cartItem ->
+                    val product = productMap[cartItem.product.id]!!
+                    CartItemResponse(
+                        id = cartItem.id!!,
+                        productId = product.id!!,
+                        productName = product.name,
+                        thumbnailUrl = product.imageUrl,
+                        description = product.description,
+                        shortDescription = product.shortDescription,
+                        price = product.price,
+                        quantity = cartItem.quantity
+                    )
+                }
+        )
+    }
+
+    @Transactional
+    fun addCartItem(userId: Long, request: AddCartItemRequest): Long {
+        val user: User =  userRepository.findById(userId)
+            .orElseThrow{ CustomException(USER_NOT_FOUND) }
+
+        val product: Product = productRepository.findById(request.productId)
+            .orElseThrow{ CustomException(PRODUCT_NOT_FOUND) }
+
+        val quantity = request.quantity
+
+        return cartItemRepository.findByUserIdAndProductId(user.id!!, product.id!!)
+            ?.apply {
+                applyQuantity(quantity)
+            }?.id
+            ?: cartItemRepository.save(
+                CartItem(
+                    user = user,
+                    product = product,
+                    quantity = quantity
+                )
+            ).id!!
+    }
+
+    @Transactional
+    fun modifyCartItem(cartItemId: Long, request: ModifyCartItemRequest){
+        val cartItem: CartItem = cartItemRepository.findById(cartItemId)
+            .orElseThrow{ CustomException(CART_ITEM_NOT_FOUND) }
+
+        cartItem.applyQuantity(request.quantity)
+    }
+
+    @Transactional
+    fun deleteCartItem(cartItemId: Long){
+        cartItemRepository.deleteById(cartItemId)
+        // deleteById 는 select 쿼리 + delete 쿼리 둘 다 발생(즉 2번 쿼리 발생)
+        // 추후 cartItem 조회 + 토큰에서 가져온 userId를 활용하여 cartItem 의 유효를 검증
+    }
+}

--- a/src/main/kotlin/com/example/commerce/cart/service/CartService.kt
+++ b/src/main/kotlin/com/example/commerce/cart/service/CartService.kt
@@ -83,7 +83,9 @@ class CartService(
 
     @Transactional
     fun deleteCartItem(cartItemId: Long){
-        cartItemRepository.deleteById(cartItemId)
+        val cartItem = cartItemRepository.findById(cartItemId)
+            .orElseThrow{ CustomException(CART_ITEM_NOT_FOUND) }
+        cartItemRepository.delete(cartItem)
         // deleteById 는 select 쿼리 + delete 쿼리 둘 다 발생(즉 2번 쿼리 발생)
         // 추후 cartItem 조회 + 토큰에서 가져온 userId를 활용하여 cartItem 의 유효를 검증
     }

--- a/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
@@ -10,6 +10,7 @@ enum class ErrorCode(
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다"),
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "상품이 존재하지 않습니다"),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "카테고리를 찾을 수 없습니다"),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "카트 아이템을 찾을 수 없습니다."),
 
     // User
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),

--- a/src/main/kotlin/com/example/commerce/product/controller/CategoryController.kt
+++ b/src/main/kotlin/com/example/commerce/product/controller/CategoryController.kt
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping(value = ["/api/v1/categories"])
+@RequestMapping(value = ["/api/v1/category"])
 class CategoryController(
     private val categoryService: CategoryService
 ) {

--- a/src/main/kotlin/com/example/commerce/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/example/commerce/product/controller/ProductController.kt
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/api/v1/products")
+@RequestMapping("/api/v1/product")
 class ProductController(
     private val productService: ProductService
 ) {

--- a/src/main/kotlin/com/example/commerce/product/domain/Category.kt
+++ b/src/main/kotlin/com/example/commerce/product/domain/Category.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.*
 
 @Entity
 @Table(
-    name = "categories",
+    name = "category",
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_category_name",

--- a/src/main/kotlin/com/example/commerce/product/domain/Product.kt
+++ b/src/main/kotlin/com/example/commerce/product/domain/Product.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.*
 import java.math.BigDecimal
 
 @Entity
-@Table(name = "products")
+@Table(name = "product")
 class Product(
     @Column(name = "name", nullable = false)
     var name: String,
@@ -26,10 +26,6 @@ class Product(
 
     @Column(name = "stock_quantity", nullable = false)
     var stockQuantity: Int,
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    var status: ProductStatus = ProductStatus.ACTIVE,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -91,13 +87,5 @@ class Product(
         if(stockQuantity < 0){
             throw CustomException(INVALID_PRODUCT_STOCK_QUANTITY)
         }
-    }
-
-    fun deactivate() {
-        this.status = ProductStatus.INACTIVE
-    }
-
-    fun activate() {
-        this.status = ProductStatus.ACTIVE
     }
 }

--- a/src/main/kotlin/com/example/commerce/product/domain/ProductStatus.kt
+++ b/src/main/kotlin/com/example/commerce/product/domain/ProductStatus.kt
@@ -1,6 +1,0 @@
-package com.example.commerce.product.domain
-
-enum class ProductStatus {
-    ACTIVE,
-    INACTIVE,
-}

--- a/src/main/kotlin/com/example/commerce/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/commerce/user/controller/UserController.kt
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/api/v1/user")
 class UserController(
     private val userService: UserService
 ) {

--- a/src/main/kotlin/com/example/commerce/user/domain/User.kt
+++ b/src/main/kotlin/com/example/commerce/user/domain/User.kt
@@ -21,5 +21,5 @@ class User ( // internal = 같은 모듈 내에서 접근 가능
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id : Long = 0
+    val id : Long? = null,
 ): BaseEntity()


### PR DESCRIPTION
## 관련 이슈

- resolves: #7 

## 작업 내용
**1. 장바구니 도메인 crud 작성**
    - 장바구니 조회, 장바구니 아이템 추가,  장바구니 아이템 수량 수정, 장바구니 아이템 삭제 기능 추가

**2. table 이름 및 uri 도메인부분 에 붙는 s(복수형) 을 단수형으로 수정**
    - user 엔티티 제외(데이터베이스 예약어 이슈)

## 특이 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 장바구니 관리 기능 추가: 장바구니 조회, 상품 추가/수정/삭제 API 엔드포인트 추가

* **개선 사항**
  * API 경로 표준화: 카테고리, 상품, 사용자 엔드포인트 경로를 단수형으로 통일
  * 상품 상태 관리 기능 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->