### PR TITLE
feat: Order 도메인 crud 추가

### DIFF
--- a/src/main/kotlin/com/example/commerce/cart/domain/Cart.kt
+++ b/src/main/kotlin/com/example/commerce/cart/domain/Cart.kt
@@ -1,0 +1,25 @@
+package com.example.commerce.cart.domain
+
+import com.example.commerce.common.exception.CustomException
+import com.example.commerce.common.exception.ErrorCode.CART_ITEM_NOT_FOUND
+import com.example.commerce.order.domain.NewOrder
+import com.example.commerce.order.domain.NewOrderItem
+
+data class Cart(
+    val userId: Long,
+    val items: List<CartItemSummary>,
+) {
+    fun toNewOrder(targetItemIds: Set<Long>): NewOrder {
+        if (items.isEmpty()) throw CustomException(CART_ITEM_NOT_FOUND)
+        return NewOrder(
+            userId = userId,
+            items = items.filter { targetItemIds.contains(it.id) }
+                .map {
+                    NewOrderItem(
+                        productId = it.productId,
+                        quantity = it.quantity
+                    )
+                }
+        )
+    }
+}

--- a/src/main/kotlin/com/example/commerce/cart/domain/CartItemSummary.kt
+++ b/src/main/kotlin/com/example/commerce/cart/domain/CartItemSummary.kt
@@ -1,0 +1,7 @@
+package com.example.commerce.cart.domain
+
+data class CartItemSummary(
+    val id: Long,
+    val productId: Long,
+    val quantity: Int
+)

--- a/src/main/kotlin/com/example/commerce/cart/dto/response/CartResponse.kt
+++ b/src/main/kotlin/com/example/commerce/cart/dto/response/CartResponse.kt
@@ -1,10 +1,11 @@
 package com.example.commerce.cart.dto.response
 
+import com.example.commerce.cart.domain.CartItem
 import java.math.BigDecimal
 
 data class CartResponse(
     val userId: Long,
-    val items: List<CartItemResponse>,
+    val items: List<CartItemResponse>
 )
 
 data class CartItemResponse(
@@ -16,4 +17,17 @@ data class CartItemResponse(
     val shortDescription: String,
     val price: BigDecimal,
     val quantity: Int,
-)
+){
+    companion object {
+        fun of(cartItem: CartItem): CartItemResponse = CartItemResponse(
+            id = cartItem.id!!,
+            productId = cartItem.product.id!!,
+            productName = cartItem.product.name,
+            thumbnailUrl = cartItem.product.imageUrl,
+            description = cartItem.product.description,
+            shortDescription = cartItem.product.shortDescription,
+            price = cartItem.product.price,
+            quantity = cartItem.quantity
+        )
+    }
+}

--- a/src/main/kotlin/com/example/commerce/cart/service/CartService.kt
+++ b/src/main/kotlin/com/example/commerce/cart/service/CartService.kt
@@ -1,15 +1,15 @@
 package com.example.commerce.cart.service
 
+import com.example.commerce.cart.domain.Cart
 import com.example.commerce.cart.domain.CartItem
+import com.example.commerce.cart.domain.CartItemSummary
 import com.example.commerce.cart.dto.request.AddCartItemRequest
 import com.example.commerce.cart.dto.request.ModifyCartItemRequest
 import com.example.commerce.cart.dto.response.CartItemResponse
 import com.example.commerce.cart.dto.response.CartResponse
 import com.example.commerce.cart.repository.CartItemRepository
 import com.example.commerce.common.exception.CustomException
-import com.example.commerce.common.exception.ErrorCode.CART_ITEM_NOT_FOUND
-import com.example.commerce.common.exception.ErrorCode.USER_NOT_FOUND
-import com.example.commerce.common.exception.ErrorCode.PRODUCT_NOT_FOUND
+import com.example.commerce.common.exception.ErrorCode.*
 import com.example.commerce.product.domain.Product
 import com.example.commerce.product.repository.ProductRepository
 import com.example.commerce.user.domain.User
@@ -44,6 +44,28 @@ class CartService(
                         description = product.description,
                         shortDescription = product.shortDescription,
                         price = product.price,
+                        quantity = cartItem.quantity
+                    )
+                }
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getCartSummary(userId: Long): Cart {
+        val user: User =  userRepository.findById(userId)
+            .orElseThrow{ CustomException(USER_NOT_FOUND) }
+        val items = cartItemRepository.findByUserId(user.id!!)
+        val productMap = productRepository.findAllById(items.map { it.product.id })
+            .associateBy{ it.id }
+
+        return Cart(
+            userId = user.id!!,
+            items = items.filter{ productMap.containsKey(it.product.id) } // 상품이 존재하는 장바구니 아이템만 선택(productMap 에 없는 상품 제외)
+                .map{ cartItem ->
+                    val product = productMap[cartItem.product.id]!!
+                    CartItemSummary(
+                        id = cartItem.id!!,
+                        productId = product.id!!,
                         quantity = cartItem.quantity
                     )
                 }

--- a/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
@@ -28,7 +28,7 @@ enum class ErrorCode(
     CATEGORY_NAME_DUPLICATED(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 카테고리 이름입니다"),
 
     // Order
-    ORDER_PRODUCT_QUANTITY_INVALID(HttpStatus.BAD_REQUEST.value(), "주문 시 상품 수량은 최소 1개 이상이여야 합니다."),
+    ORDER_PRODUCT_QUANTITY_INVALID(HttpStatus.BAD_REQUEST.value(), "주문 시 상품 수량은 최소 1개 이상이어야 합니다."),
     PRODUCT_MISMATCH_IN_ORDER(HttpStatus.BAD_REQUEST.value(), "주문의 상품과 조회한 상품이 매칭되지 않습니다."),
     ORDER_USER_NOT_MATCHING(HttpStatus.BAD_REQUEST.value(), "주문을 조회할 권한이 존재하지 않습니다."),
 

--- a/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
@@ -1,5 +1,6 @@
 package com.example.commerce.common.exception
 
+import org.apache.tomcat.util.http.parser.HttpParser
 import org.springframework.http.HttpStatus
 
 enum class ErrorCode(
@@ -11,7 +12,8 @@ enum class ErrorCode(
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "상품이 존재하지 않습니다"),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "카테고리를 찾을 수 없습니다"),
     CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "카트 아이템을 찾을 수 없습니다."),
-
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "주문을 찾을 수 없습니다."),
+    ORDER_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "주문의 상품을 찾을 수 없습니다."),
     // User
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
 
@@ -26,6 +28,9 @@ enum class ErrorCode(
     PRODUCT_CATEGORY_NOT_MATCHING(HttpStatus.BAD_REQUEST.value(), "상품에 카테고리가 매핑되어 있지 않습니다."),
     CATEGORY_NAME_DUPLICATED(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 카테고리 이름입니다"),
 
+    // Order
+    ORDER_PRODUCT_QUANTITY_INVALID(HttpStatus.BAD_REQUEST.value(), "주문 시 상품 수량은 최소 1개 이상이여야 합니다."),
+    PRODUCT_MISMATCH_IN_ORDER(HttpStatus.BAD_REQUEST.value(), "주문의 상품과 조회한 상품이 매칭되지 않습니다."),
     // Database
     DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT.value(), "데이터베이스 무결성 제약조건 위반이 발생했습니다."),
 

--- a/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/example/commerce/common/exception/ErrorCode.kt
@@ -1,6 +1,5 @@
 package com.example.commerce.common.exception
 
-import org.apache.tomcat.util.http.parser.HttpParser
 import org.springframework.http.HttpStatus
 
 enum class ErrorCode(
@@ -31,6 +30,8 @@ enum class ErrorCode(
     // Order
     ORDER_PRODUCT_QUANTITY_INVALID(HttpStatus.BAD_REQUEST.value(), "주문 시 상품 수량은 최소 1개 이상이여야 합니다."),
     PRODUCT_MISMATCH_IN_ORDER(HttpStatus.BAD_REQUEST.value(), "주문의 상품과 조회한 상품이 매칭되지 않습니다."),
+    ORDER_USER_NOT_MATCHING(HttpStatus.BAD_REQUEST.value(), "주문을 조회할 권한이 존재하지 않습니다."),
+
     // Database
     DATA_INTEGRITY_VIOLATION(HttpStatus.CONFLICT.value(), "데이터베이스 무결성 제약조건 위반이 발생했습니다."),
 

--- a/src/main/kotlin/com/example/commerce/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/commerce/order/controller/OrderController.kt
@@ -1,0 +1,85 @@
+package com.example.commerce.order.controller
+
+import com.example.commerce.cart.service.CartService
+import com.example.commerce.order.domain.OrderState
+import com.example.commerce.order.dto.request.CreateOrderFromCartRequest
+import com.example.commerce.order.dto.request.CreateOrderRequest
+import com.example.commerce.order.dto.response.CreateOrderResponse
+import com.example.commerce.order.dto.response.OrderListResponse
+import com.example.commerce.order.dto.response.OrderResponse
+import com.example.commerce.order.service.OrderService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/order")
+class OrderController(
+    private val orderService: OrderService,
+    private val cartService: CartService
+) {
+    @PostMapping("/create")
+    fun createOrder(
+        @RequestParam("userId") userId: Long,
+        @RequestBody request: CreateOrderRequest
+    ): ResponseEntity<CreateOrderResponse>{
+        val response = orderService.create(
+            userId = userId,
+            newOrder = request.toNewOrder(userId),
+        )
+        val status = HttpStatus.CREATED
+        return ResponseEntity.status(status).body(
+            CreateOrderResponse(
+                orderKey = response
+            )
+        )
+    }
+
+    @PostMapping("/cart-orders/create")
+    fun createFromCart(
+        @RequestParam("userId") userId: Long,
+        @RequestBody request: CreateOrderFromCartRequest
+    ): ResponseEntity<CreateOrderResponse>{
+        val cart = cartService.getCartSummary(userId)
+        val response = orderService.create(
+            userId = userId,
+            newOrder = cart.toNewOrder(request.cartItemIds)
+        )
+        val status = HttpStatus.CREATED
+        return ResponseEntity.status(status).body(
+            CreateOrderResponse(
+                orderKey = response,
+            )
+        )
+    }
+
+    @GetMapping("/catalog")
+    fun getOrders(
+        @RequestParam("userId") userId: Long,
+    ): ResponseEntity<List<OrderListResponse>> {
+        val response = orderService.getOrders(userId)
+        val status = HttpStatus.OK
+        return ResponseEntity.status(status).body(
+            OrderListResponse.of(
+                orders = response
+            )
+        )
+    }
+
+    @GetMapping("/{order-key}")
+    fun getOrder(
+        @RequestParam("userId") userId: Long,
+        @PathVariable("order-key") orderKey: String,
+        @RequestParam("orderState") orderState: OrderState,
+    ): ResponseEntity<OrderResponse> {
+        val response = orderService.getOrder(
+            userId = userId,
+            orderKey = orderKey,
+            orderState = orderState
+        )
+        val status = HttpStatus.OK
+        return ResponseEntity.status(status).body(response)
+    }
+
+    // 상품 체크(포인트, 쿠폰 등 적용은 나중에)
+}

--- a/src/main/kotlin/com/example/commerce/order/domain/NewOrder.kt
+++ b/src/main/kotlin/com/example/commerce/order/domain/NewOrder.kt
@@ -1,0 +1,6 @@
+package com.example.commerce.order.domain
+
+data class NewOrder(
+    val userId: Long,
+    val items: List<NewOrderItem>
+)

--- a/src/main/kotlin/com/example/commerce/order/domain/NewOrderItem.kt
+++ b/src/main/kotlin/com/example/commerce/order/domain/NewOrderItem.kt
@@ -1,0 +1,6 @@
+package com.example.commerce.order.domain
+
+data class NewOrderItem(
+    val productId: Long,
+    val quantity: Int,
+)

--- a/src/main/kotlin/com/example/commerce/order/domain/Order.kt
+++ b/src/main/kotlin/com/example/commerce/order/domain/Order.kt
@@ -1,0 +1,41 @@
+package com.example.commerce.order.domain
+
+import com.example.commerce.common.BaseEntity
+import com.example.commerce.user.domain.User
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "orders")
+class Order(
+    @Column(name="order_key", nullable = false)
+    val key: String,
+
+    @Column(name = "name", nullable = false)
+    var name: String,
+
+    @Column(name = "total_price", nullable = false)
+    var totalPrice: BigDecimal,
+
+    state: OrderState,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+) : BaseEntity() {
+    @Enumerated(EnumType.STRING)
+    var state: OrderState = state // 파라미터로 전달받은 state
+        protected set
+
+    fun paid() {
+        state = OrderState.PAID
+    }
+
+    fun canceled() {
+        state = OrderState.CANCELED
+    }
+}

--- a/src/main/kotlin/com/example/commerce/order/domain/OrderItem.kt
+++ b/src/main/kotlin/com/example/commerce/order/domain/OrderItem.kt
@@ -1,0 +1,41 @@
+package com.example.commerce.order.domain
+
+import com.example.commerce.common.BaseEntity
+import com.example.commerce.product.domain.Product
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+@Table(name = "order_item")
+class OrderItem(
+    @Column(name = "product_name", nullable = false)
+    val productName: String,
+
+    @Column(name = "thumbnail_url", nullable = false)
+    val thumbnailUrl: String,
+
+    @Column(name = "short_description", nullable = false)
+    val shortDescription: String,
+
+    @Column(name = "quantity", nullable = false)
+    val quantity: Int,
+
+    @Column(name = "unit_price", nullable = false)
+    val unitPrice: BigDecimal,
+
+    @Column(name = "total_price", nullable = false)
+    val totalPrice: BigDecimal,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    val order: Order,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    val product: Product,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+) : BaseEntity(){
+}

--- a/src/main/kotlin/com/example/commerce/order/domain/OrderState.kt
+++ b/src/main/kotlin/com/example/commerce/order/domain/OrderState.kt
@@ -1,0 +1,7 @@
+package com.example.commerce.order.domain
+
+enum class OrderState {
+    CREATED,
+    PAID,
+    CANCELED
+}

--- a/src/main/kotlin/com/example/commerce/order/domain/OrderSummary.kt
+++ b/src/main/kotlin/com/example/commerce/order/domain/OrderSummary.kt
@@ -1,0 +1,12 @@
+package com.example.commerce.order.domain
+
+import java.math.BigDecimal
+
+data class OrderSummary(
+    val id: Long,
+    val key: String,
+    val name: String,
+    val userId: Long,
+    val totalPrice: BigDecimal,
+    val state: OrderState,
+)

--- a/src/main/kotlin/com/example/commerce/order/dto/request/CreateOrderFromCartRequest.kt
+++ b/src/main/kotlin/com/example/commerce/order/dto/request/CreateOrderFromCartRequest.kt
@@ -1,0 +1,5 @@
+package com.example.commerce.order.dto.request
+
+data class CreateOrderFromCartRequest(
+    val cartItemIds: Set<Long>
+)

--- a/src/main/kotlin/com/example/commerce/order/dto/request/CreateOrderRequest.kt
+++ b/src/main/kotlin/com/example/commerce/order/dto/request/CreateOrderRequest.kt
@@ -1,0 +1,19 @@
+package com.example.commerce.order.dto.request
+
+import com.example.commerce.common.exception.CustomException
+import com.example.commerce.common.exception.ErrorCode.ORDER_PRODUCT_QUANTITY_INVALID
+import com.example.commerce.order.domain.NewOrder
+import com.example.commerce.order.domain.NewOrderItem
+
+data class CreateOrderRequest(
+    val productId: Long,
+    val quantity: Int
+) {
+    fun toNewOrder(userId: Long): NewOrder {
+        if(quantity <= 0) throw CustomException(ORDER_PRODUCT_QUANTITY_INVALID)
+        return NewOrder(
+            userId = userId,
+            items = listOf(NewOrderItem(productId, quantity))
+        )
+    }
+}

--- a/src/main/kotlin/com/example/commerce/order/dto/response/CreateOrderResponse.kt
+++ b/src/main/kotlin/com/example/commerce/order/dto/response/CreateOrderResponse.kt
@@ -1,0 +1,5 @@
+package com.example.commerce.order.dto.response
+
+data class CreateOrderResponse(
+    val orderKey: String
+)

--- a/src/main/kotlin/com/example/commerce/order/dto/response/OrderItemResponse.kt
+++ b/src/main/kotlin/com/example/commerce/order/dto/response/OrderItemResponse.kt
@@ -1,0 +1,13 @@
+package com.example.commerce.order.dto.response
+
+import java.math.BigDecimal
+
+data class OrderItemResponse(
+    val productId: Long,
+    val productName: String,
+    val thumbnailUrl: String,
+    val shortDescription: String,
+    val quantity: Int,
+    val unitPrice: BigDecimal,
+    val totalPrice: BigDecimal,
+)

--- a/src/main/kotlin/com/example/commerce/order/dto/response/OrderListResponse.kt
+++ b/src/main/kotlin/com/example/commerce/order/dto/response/OrderListResponse.kt
@@ -1,0 +1,27 @@
+package com.example.commerce.order.dto.response
+
+import com.example.commerce.order.domain.OrderState
+import com.example.commerce.order.domain.OrderSummary
+import java.math.BigDecimal
+
+data class OrderListResponse(
+    val key: String,
+    val name: String,
+    val totalPrice: BigDecimal,
+    val state: OrderState
+){
+    companion object {
+        private fun of(order: OrderSummary): OrderListResponse{
+            return OrderListResponse(
+                key = order.key,
+                name = order.name,
+                totalPrice = order.totalPrice,
+                state = order.state
+            )
+        }
+
+        fun of(orders: List<OrderSummary>): List<OrderListResponse>{ // 리스트 변환만 외부에 노출, 내부적으로 처리
+            return orders.map{ of(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/example/commerce/order/dto/response/OrderResponse.kt
+++ b/src/main/kotlin/com/example/commerce/order/dto/response/OrderResponse.kt
@@ -1,0 +1,14 @@
+package com.example.commerce.order.dto.response
+
+import com.example.commerce.order.domain.OrderState
+import java.math.BigDecimal
+
+data class OrderResponse(
+    val id: Long,
+    val userId: Long,
+    val key: String,
+    val name: String,
+    val totalPrice: BigDecimal,
+    val state: OrderState,
+    val items: List<OrderItemResponse>,
+)

--- a/src/main/kotlin/com/example/commerce/order/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/example/commerce/order/repository/OrderItemRepository.kt
@@ -1,0 +1,8 @@
+package com.example.commerce.order.repository
+
+import com.example.commerce.order.domain.OrderItem
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OrderItemRepository : JpaRepository<OrderItem, Long> {
+    fun findByOrderId(orderId: Long): List<OrderItem>
+}

--- a/src/main/kotlin/com/example/commerce/order/repository/OrderRepository.kt
+++ b/src/main/kotlin/com/example/commerce/order/repository/OrderRepository.kt
@@ -1,0 +1,11 @@
+package com.example.commerce.order.repository
+
+import com.example.commerce.order.domain.Order
+import com.example.commerce.order.domain.OrderState
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface OrderRepository : JpaRepository<Order, Long> {
+    fun findByUserIdAndStateOrderByIdDesc(userId: Long, state: OrderState): List<Order>
+    fun findByKeyAndState(key: String, state: OrderState): Optional<Order>
+}

--- a/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
@@ -95,7 +95,7 @@ class OrderService(
             .orElseThrow{ CustomException(ORDER_NOT_FOUND)}
 
         if(user.id != order.user.id){
-            throw CustomException(O)
+            throw CustomException(ORDER_USER_NOT_MATCHING)
         }
 
         val orderItems = orderItemRepository.findByOrderId(order.id!!)

--- a/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
@@ -26,8 +26,6 @@ class OrderService(
         val user = userRepository.findById(userId)
             .orElseThrow{ CustomException(USER_NOT_FOUND) }
 
-        if(newOrder.items.isEmpty()) throw CustomException(ORDER_PRODUCT_NOT_FOUND)
-
         val orderProductIds = newOrder.items.map { it.productId }.toSet()
         val productMap = productRepository.findByIdIn(orderProductIds).associateBy { it.id } // product의 id값을 key로 map을 만든다
         if (productMap.isEmpty()) throw CustomException(PRODUCT_NOT_FOUND)

--- a/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
@@ -26,6 +26,8 @@ class OrderService(
         val user = userRepository.findById(userId)
             .orElseThrow{ CustomException(USER_NOT_FOUND) }
 
+        if(newOrder.items.isEmpty()) throw CustomException(ORDER_PRODUCT_NOT_FOUND)
+
         val orderProductIds = newOrder.items.map { it.productId }.toSet()
         val productMap = productRepository.findByIdIn(orderProductIds).associateBy { it.id } // product의 id값을 key로 map을 만든다
         if (productMap.isEmpty()) throw CustomException(PRODUCT_NOT_FOUND)
@@ -91,6 +93,10 @@ class OrderService(
 
         val order = orderRepository.findByKeyAndState(orderKey, orderState)
             .orElseThrow{ CustomException(ORDER_NOT_FOUND)}
+
+        if(user.id != order.user.id){
+            throw CustomException(O)
+        }
 
         val orderItems = orderItemRepository.findByOrderId(order.id!!)
         if(orderItems.isEmpty()) throw CustomException(ORDER_PRODUCT_NOT_FOUND)

--- a/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/commerce/order/service/OrderService.kt
@@ -1,0 +1,118 @@
+package com.example.commerce.order.service
+
+import com.example.commerce.common.exception.CustomException
+import com.example.commerce.common.exception.ErrorCode.*
+import com.example.commerce.order.domain.*
+import com.example.commerce.order.dto.response.OrderItemResponse
+import com.example.commerce.order.dto.response.OrderResponse
+import com.example.commerce.order.repository.OrderItemRepository
+import com.example.commerce.order.repository.OrderRepository
+import com.example.commerce.order.support.OrderKeyGenerator
+import com.example.commerce.product.repository.ProductRepository
+import com.example.commerce.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OrderService(
+    private val orderRepository: OrderRepository,
+    private val orderItemRepository: OrderItemRepository,
+    private val userRepository: UserRepository,
+    private val productRepository: ProductRepository,
+    private val orderKeyGenerator: OrderKeyGenerator,
+) {
+    @Transactional
+    fun create(userId: Long, newOrder: NewOrder): String{
+        val user = userRepository.findById(userId)
+            .orElseThrow{ CustomException(USER_NOT_FOUND) }
+
+        val orderProductIds = newOrder.items.map { it.productId }.toSet()
+        val productMap = productRepository.findByIdIn(orderProductIds).associateBy { it.id } // product의 id값을 key로 map을 만든다
+        if (productMap.isEmpty()) throw CustomException(PRODUCT_NOT_FOUND)
+        if (productMap.keys != orderProductIds) throw CustomException(PRODUCT_MISMATCH_IN_ORDER)
+
+        val order = Order(
+            user = user,
+            key = orderKeyGenerator.generate(),
+            name = newOrder.items.first().let { productMap[it.productId]!!.name + if (newOrder.items.size > 1) " 외 ${newOrder.items.size - 1}개" else "" },
+            totalPrice = newOrder.items.sumOf { productMap[it.productId]!!.price.multiply(it.quantity.toBigDecimal()) },
+            state = OrderState.CREATED,
+        )
+
+        val savedOrder = orderRepository.save(order)
+
+        orderItemRepository.saveAll(
+            newOrder.items.map {
+                val product = productMap[it.productId]!!
+                OrderItem(
+                    productName = product.name,
+                    thumbnailUrl = product.imageUrl,
+                    shortDescription = product.shortDescription,
+                    quantity = it.quantity,
+                    unitPrice = product.price,
+                    totalPrice = product.price.multiply(it.quantity.toBigDecimal()),
+                    order = savedOrder,
+                    product = product
+                )
+            },
+        )
+
+        return savedOrder.key
+    }
+
+    @Transactional(readOnly = true)
+    fun getOrders(userId: Long): List<OrderSummary>{
+        val user = userRepository.findById(userId)
+            .orElseThrow{ CustomException(USER_NOT_FOUND) }
+
+        val orders = orderRepository.findByUserIdAndStateOrderByIdDesc(userId, OrderState.PAID)
+        if(orders.isEmpty()) return emptyList()
+
+        return orders.map {
+            OrderSummary(
+                id = it.id!!,
+                key = it.key,
+                name = it.name,
+                userId = user.id!!,
+                totalPrice = it.totalPrice,
+                state = it.state
+            )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getOrder(
+        userId: Long,
+        orderKey: String,
+        orderState: OrderState,
+    ): OrderResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow{ CustomException(USER_NOT_FOUND) }
+
+        val order = orderRepository.findByKeyAndState(orderKey, orderState)
+            .orElseThrow{ CustomException(ORDER_NOT_FOUND)}
+
+        val orderItems = orderItemRepository.findByOrderId(order.id!!)
+        if(orderItems.isEmpty()) throw CustomException(ORDER_PRODUCT_NOT_FOUND)
+
+        return OrderResponse(
+            id = order.id!!,
+            key = order.key,
+            name = order.name,
+            userId = user.id!!,
+            totalPrice = order.totalPrice,
+            state = order.state,
+            items = orderItems.map {
+                OrderItemResponse(
+                    productId = it.product.id!!,
+                    productName = it.productName,
+                    thumbnailUrl = it.thumbnailUrl,
+                    shortDescription = it.shortDescription,
+                    quantity = it.quantity,
+                    unitPrice = it.unitPrice,
+                    totalPrice = it.totalPrice
+                )
+            }
+        )
+    }
+}

--- a/src/main/kotlin/com/example/commerce/order/support/OrderKeyGenerator.kt
+++ b/src/main/kotlin/com/example/commerce/order/support/OrderKeyGenerator.kt
@@ -1,0 +1,19 @@
+package com.example.commerce.order.support
+
+import org.springframework.stereotype.Component
+import java.nio.ByteBuffer
+import java.util.*
+
+@Component
+class OrderKeyGenerator {
+    fun generate(): String{
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(
+            ByteBuffer.allocate(16).apply {
+                UUID.randomUUID().also {
+                    putLong(it.mostSignificantBits)
+                    putLong(it.leastSignificantBits)
+                }
+            }.array(),
+        )
+    }
+}

--- a/src/main/kotlin/com/example/commerce/product/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/example/commerce/product/repository/ProductRepository.kt
@@ -4,4 +4,5 @@ import com.example.commerce.product.domain.Product
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProductRepository : JpaRepository<Product, Long> {
+    fun findByIdIn(ids: Collection<Long>): List<Product>
 }


### PR DESCRIPTION
## 관련 이슈

- resolves: #8 

## 작업 내용
**1. ~Dto 클래스 제거 후 도메인 클래스로 역할 변경**
    - Dto 는 http 요청/응답 책임을 가지고, 서비스에선 도메인 객체를 활용

**2. feat: 주문 및 주문 목록 조회 기능 추가**
    - 주문 목록은 결제 된 목록만 확인, 주문은 상태값 기반 조회

**3. feat: 주문 생성 기능 추가**
    - 상품에서 바로 단건 주문, 장바구니 주문 기능 추가
    - 둘다 같은 create 서비스 메서드 활용

## 특이 사항

<!-- 프로젝트 실행에 영향을 미치는 중요한 변경사항이나 주의사항 등을 기술해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개별 상품 및 장바구니 기반 주문 생성(주문키 반환), 주문 목록·상세 조회 API 추가
  * 주문 항목·요약 표현과 주문 상태(CREATED/PAID/CANCELED) 지원, 주문 키 생성 로직 도입
  * 장바구니 요약 조회 및 장바구니 선택 항목으로 주문 생성 지원
* **버그 수정 / 개선**
  * 주문·장바구니 입력 검증 강화 및 관련 오류 코드(수량/상품/주문 권한 등) 추가 정비

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->